### PR TITLE
kubes_google helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [0.4.1 UNRELEASED]
+- kubes init: default namespace now includes Kubes.env
+- fix kubes deploy: compile it gets called once and output folder kept
+- include kubes_google dependency helpers
+
 ## [0.4.0]
 - #26 features: kubes vs kubectl hooks, prune, etc
 - hooks: kubes, kubectl, docker breaking changes.

--- a/docs/_docs/learn/dsl/review-project.md
+++ b/docs/_docs/learn/dsl/review-project.md
@@ -11,9 +11,11 @@ We'll create a namespace for the app resources:
 .kubes/resources/shared/namespace.rb
 
 ```ruby
-name "demo"
+name "demo-#{Kubes.env}"
 labels(app: "demo")
 ```
+
+Notice, the `#{Kubes.env}`. Kubes adds the env to the namespace by default. You can change this with the `init --namespace` option.
 
 ## Deployment
 
@@ -39,7 +41,7 @@ Also let's check the files in the base folder.
 .kubes/resources/base/all.rb
 
 ```ruby
-namespace "default"
+namespace "demo-#{Kubes.env}"
 labels(app: "demo")
 ```
 

--- a/docs/_docs/learn/yaml/review-project.md
+++ b/docs/_docs/learn/yaml/review-project.md
@@ -14,10 +14,12 @@ We'll create a namespace for the app resources:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: demo
+  name: demo-<%= Kubes.env %>
   labels:
     app: demo
 ```
+
+Notice, the `<%= Kubes.env %>`. Kubes adds the env to the namespace by default. You can change this with the `init --namespace` option.
 
 ## Deployment
 
@@ -57,7 +59,7 @@ Also let's check the files in the base folder.
 
 ```yaml
 metadata:
-  namespace: demo
+  namespace: demo-<%= Kubes.env %>
 ```
 
 .kubes/resources/base/deployment.yaml

--- a/kubes.gemspec
+++ b/kubes.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor"
   spec.add_dependency "zeitwerk"
 
+  # core helper libs
+  spec.add_dependency "kubes_google"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "cli_markdown"

--- a/lib/kubes.rb
+++ b/lib/kubes.rb
@@ -14,6 +14,9 @@ require "memoist"
 require "rainbow/ext/string"
 require "yaml"
 
+# core helper libraries
+require "kubes_google"
+
 DslEvaluator.backtrace_reject = ".kubes"
 
 require "kubes/autoloader"

--- a/lib/kubes/cli/compile.rb
+++ b/lib/kubes/cli/compile.rb
@@ -1,8 +1,16 @@
 class Kubes::CLI
   class Compile < Base
+    # Separate command like prune can call compile. Apply also calls Prune.
+    # Instead of moving Compile out of Prune, will use this class variable.
+    # In case we have other cases where compile is called in another area.
+    # We only want compiled to be called once so hooks only fire once.
+    # Done here so we don't clean and remove the .kubes/output folder.
+    @@compiled = false
     def run
+      return if @@compiled
       Clean.new(@options.merge(mute: true)).run
       Kubes::Compiler.new(@options).run
+      @@compiled = true
     end
   end
 end

--- a/lib/kubes/cli/init.rb
+++ b/lib/kubes/cli/init.rb
@@ -6,7 +6,7 @@ class Kubes::CLI
         [:force, type: :boolean, desc: "Bypass overwrite are you sure prompt for existing files"],
         [:type, aliases: ["t"], default: "yaml", desc: "Type: dsl or yaml"],
         [:repo, required: true, desc: "Docker repo name. Example: user/repo. Configures .kubes/config.rb"],
-        [:namespace, aliases: ["n"], desc: "Namespace to use, defaults to the app option"],
+        [:namespace, aliases: ["n"], desc: "Namespace to use, defaults to APP-ENV. IE: demo-dev"],
       ]
     end
 
@@ -19,7 +19,7 @@ class Kubes::CLI
     end
 
     def namespace
-      @options[:namespace] || @options[:app]
+      @options[:namespace] || "#{@options[:app]}-#{Kubes.env}"
     end
 
     def excludes

--- a/lib/kubes/cli/init.rb
+++ b/lib/kubes/cli/init.rb
@@ -19,7 +19,12 @@ class Kubes::CLI
     end
 
     def namespace
-      @options[:namespace] || "#{@options[:app]}-#{Kubes.env}"
+      @options[:namespace] || default_namespace
+    end
+
+    def default_namespace
+      env = @options[:type] == "yaml" ? '<%= Kubes.env %>' : '#{Kubes.env}'
+      "#{app}-#{env}"
     end
 
     def excludes

--- a/lib/kubes/compiler.rb
+++ b/lib/kubes/compiler.rb
@@ -8,13 +8,7 @@ module Kubes
       @options = options
     end
 
-    # Separate command like prune can call compile. Apply also calls Prune.
-    # Instead of moving Compile out of Prune, will use this class variable.
-    # In case we have other cases where compile is called in another area.
-    # We only want compiled to be called once so hooks only fire once.
-    @@compiled = false
     def run
-      return if @@compiled
       Kubes.config # trigger config load. So can set ENV['VAR'] in config/envs/dev.rb etc
       run_hooks("kubes.rb", name: "compile") do
         results = resources.map do |path|
@@ -28,7 +22,6 @@ module Kubes
       end
 
       puts "Compiled  .kubes/resources files to .kubes/output" if show_compiled_message?
-      @@compiled = true
     end
 
     def resources


### PR DESCRIPTION
* kubes init: default namespace now includes env
* fix kubes deploy: compile it gets called once and output folder kept
* include kubes_google dependency