### PR TITLE
State docker image

### DIFF
--- a/docs/_docs/config/reference.md
+++ b/docs/_docs/config/reference.md
@@ -18,5 +18,5 @@ logger.level | Logger level. Can also be set with `KUBES_LOG_LEVEL` env var | in
 repo | The Docker repo to use. Required to be set. | nil
 repo_auto_auth | Whether or not to try to auth authorize docker repo registry if not yet logged in. Can also be set with env var `KUBES_REPO_AUTO_AUTO` | true
 skip | List of resources to skip. Can also be set with the `KUBES_SKIP` env var. `KUBES_SKIP` should be a list of strings separated by spaces. It adds onto the `config.skip` option. | []
-state.docker_image_path | Where to store the state file with the last build Docker image. | .kubes/state/docker_image.txt
+state.path | Where to store the state file with the last build Docker image. | .kubes/state/KUBES_env/data.json
 suffix_hash | Whether or not to append suffix hash to ConfigMap and Secret | true

--- a/lib/kubes/cli/compile.rb
+++ b/lib/kubes/cli/compile.rb
@@ -16,7 +16,7 @@ class Kubes::CLI
 
     # auto build docker image and push image if kubes docker build not yet called
     def build_docker_image
-      return if File.exist?("#{Kubes.root}/.kubes/state/docker_image.txt")
+      return if File.exist?(Kubes.config.state.path)
       Build.new(@options).run
     end
   end

--- a/lib/kubes/command.rb
+++ b/lib/kubes/command.rb
@@ -57,6 +57,7 @@ module Kubes
       end
 
       def check_project!(command_name)
+        return if command_name.nil?
         return if %w[-h -v completion completion_script help init new version].include?(command_name)
         Kubes.check_project!
       end

--- a/lib/kubes/compiler/shared/helpers.rb
+++ b/lib/kubes/compiler/shared/helpers.rb
@@ -1,4 +1,5 @@
 require "base64"
+require "json"
 
 module Kubes::Compiler::Shared
   module Helpers
@@ -17,11 +18,12 @@ module Kubes::Compiler::Shared
     end
 
     def built_image_helper
-      path = Kubes.config.state.docker_image_path
+      path = Kubes.config.state.path
       unless File.exist?(path)
         raise Kubes::MissingDockerImage.new("Missing file with docker image built by kubes: #{path}. Try first running: kubes docker build")
       end
-      IO.read(path)
+      data = JSON.load(IO.read(path))
+      data['image']
     end
 
     def with_extra(value)

--- a/lib/kubes/config.rb
+++ b/lib/kubes/config.rb
@@ -39,7 +39,7 @@ module Kubes
       config.skip = []
 
       config.state = ActiveSupport::OrderedOptions.new
-      config.state.docker_image_path = "#{Kubes.root}/.kubes/state/docker_image.txt"
+      config.state.path = "#{Kubes.root}/.kubes/state/#{Kubes.env}/data.json"
 
       config.suffix_hash = true # append suffix hash to ConfigMap and Secret
 


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Save kubes state file that stores the last build docker image name to an env based folder. So don't accidentally deploy an image mean for dev to prod and vice versa. Can override override with config.

.kubes/config.rb

```ruby
Kubes.configure do |config|
  config.state.path = ".kubes/state/#{Kubes.env}/data.json"
end
```

## How to Test

Go through regular Kubes QA matrix.

## Version Changes

Patch