### PR TITLE
call run method to respect config.suffix_hash

### DIFF
--- a/lib/kubes/compiler/decorator/base.rb
+++ b/lib/kubes/compiler/decorator/base.rb
@@ -12,9 +12,9 @@ module Kubes::Compiler::Decorator
 
     def result
       if @data.key?(Kubes::Compiler::Dsl::Core::Blocks)
-        @data.results.each { |k,v| process(v) } # returns nil
+        @data.results.each { |k,v| run(v) } # returns nil
       else
-        process # processes and returns @data
+        run # processes and returns @data
       end
       @data # important to return @data so we keep the original @data structure: Blocks or Hash
     end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Call the run method to respect the `config.suffix_hash` option for the decorators. This fixes the `config.suffix_hash` option.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

Run `kubes compile` and make sure that there's no suffix hash added to the secret name. Example:

    $ grep suffix_hash .kubes/config.rb 
      config.suffix_hash = false
    $ cat .kubes/resources/shared/secret.yaml
    apiVersion: v1
    kind: Secret
    metadata:
      name: demo
      labels:
        app: demo
    data:
      username: dXNlcg==
      password: cGFzcw==
    $ kubes compile
    Compiled  .kubes/resources files to .kubes/output
    $ cat .kubes/output/shared/secret.yaml
    ---
    metadata:
      namespace: demo-dev
      labels:
        app: demo
      name: demo
    apiVersion: v1
    kind: Secret
    data:
      username: dXNlcg==
      password: cGFzcw==
    $ 

## Version Changes

Patch