### PR TITLE
use deep_merge overwrite_arrays option

### DIFF
--- a/lib/kubes/compiler/dsl/core/fields.rb
+++ b/lib/kubes/compiler/dsl/core/fields.rb
@@ -64,7 +64,7 @@ module Kubes::Compiler::Dsl::Core
         result = instance_variable_get(ivar)
         result = {} if mode == "reset" # allow user to override with mode: reset option
         result ||= {} # maintain value for layering
-        result.deeper_merge!(value)
+        Kubes.deep_merge!(result, value)
         instance_variable_set(ivar, result)
       end
     end

--- a/lib/kubes/compiler/dsl/syntax/resource.rb
+++ b/lib/kubes/compiler/dsl/syntax/resource.rb
@@ -18,7 +18,7 @@ module Kubes::Compiler::Dsl::Syntax
     # top-level of resource is quite common
     def default_result
       data = top.merge(default_top)
-      data.deeper_merge!(default_result_append)
+      Kubes.deep_merge!(data, default_result_append)
       data.deep_stringify_keys!
       HashSqueezer.squeeze(data)
     end
@@ -63,7 +63,7 @@ module Kubes::Compiler::Dsl::Syntax
 
     # For generic kind
     def field(name, data)
-      top.deeper_merge!(name => data)
+      Kubes.deep_merge!(top, {name => data})
     end
   end
 end

--- a/lib/kubes/compiler/strategy/dispatcher.rb
+++ b/lib/kubes/compiler/strategy/dispatcher.rb
@@ -4,8 +4,8 @@ class Kubes::Compiler::Strategy
       result = render(@path) # main
       results = [result].flatten # ensure array
       data = results.map! do |main|
-        hash = pre_layer.deeper_merge!(main) # need the ! or deep_merge returns original hash
-        hash.deeper_merge!(post_layer)
+        hash = Kubes.deep_merge!(pre_layer, main)
+        Kubes.deep_merge!(hash, post_layer)
       end
       Result.new(@save_file, data)
     end

--- a/lib/kubes/core.rb
+++ b/lib/kubes/core.rb
@@ -34,5 +34,11 @@ module Kubes
       logger.error "ERROR: It doesnt look like this is a kubes project. Are you sure you are in a kubes project?".color(:red)
       ENV['TS_TEST'] ? raise : exit(1)
     end
+
+    # wrapper to ensure we use the same deeper_merge options everywhere
+    def deep_merge!(a, b)
+      a.deeper_merge!(b, overwrite_arrays: true)
+      a
+    end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes #45

## Context

When specifying `targetPort` in a service.rb DSL definition, it adds to the ports array instead of overriding the existing one.

## How to Test

    $ cat .kubes/resources/web/service.rb 
    name "web"
    labels(role: "web")
    
    # Optional since default port is 80
    # port 80
    targetPort 8080 # expose port in Dockerfile
    
    # More docs: kubes.guru/docs/dsl/resources/service/
    $ kubes compile ; cat .kubes/output/web/service.yaml
    Compiled  .kubes/resources files to .kubes/output
    ---
    apiVersion: v1
    kind: Service
    metadata:
      labels:
        app: demo
        role: web
      namespace: demo-dev
      name: web
    spec:
      ports:
      - port: 80
        protocol: TCP
        targetPort: 8080
      selector:
        app: demo
        role: web
      type: ClusterIP
    $ 

## Version Changes

Patch