### PR TITLE
Gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,29 @@
+---
+variables:
+  DEFAULT_DOCKER_FILE: "Dockerfile.amazon2"
+
+build-n-push-latest:
+  stage: build
+  image: docker:stable
+  rules:
+    - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
+  services:
+    - docker:dind
+  stage: prepare
+  script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker build -t $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:latest -f $DEFAULT_DOCKER_FILE .
+    - docker push $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:latest
+
+build-n-push-version:
+  stage: build
+  image: docker:stable
+  rules:
+    - if: $CI_COMMIT_TAG =~ /[v][0-9]+[.][0-9]+[.][0-9]+/
+  services:
+    - docker:dind
+  stage: prepare
+  script:
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker build -t $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:CI_COMMIT_TAG -f $DEFAULT_DOCKER_FILE .
+    - docker push $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:$CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@
 variables:
   DEFAULT_DOCKER_FILE: "Dockerfile.amazon2"
 
+stages:
+  - build
+
 build-n-push-latest:
   stage: build
   image: docker:stable
@@ -9,11 +12,10 @@ build-n-push-latest:
     - if: $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
   services:
     - docker:dind
-  stage: prepare
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker build -t $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:latest -f $DEFAULT_DOCKER_FILE .
-    - docker push $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:latest
+    - docker build -t $CI_REGISTRY/$CI_PROJECT_PATH/kubes:latest -f $DEFAULT_DOCKER_FILE .
+    - docker push $CI_REGISTRY/$CI_PROJECT_PATH/kubes:latest
 
 build-n-push-version:
   stage: build
@@ -22,8 +24,7 @@ build-n-push-version:
     - if: $CI_COMMIT_TAG =~ /[v][0-9]+[.][0-9]+[.][0-9]+/
   services:
     - docker:dind
-  stage: prepare
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker build -t $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:CI_COMMIT_TAG -f $DEFAULT_DOCKER_FILE .
-    - docker push $CI_REGISTRY/$CI_PROJECT_PATH_SLUG/kubes:$CI_COMMIT_TAG
+    - docker build -t $CI_REGISTRY/$CI_PROJECT_PATH/kubes:CI_COMMIT_TAG -f $DEFAULT_DOCKER_FILE .
+    - docker push $CI_REGISTRY/$CI_PROJECT_PATH/kubes:$CI_COMMIT_TAG

--- a/Dockerfile.amazon2
+++ b/Dockerfile.amazon2
@@ -1,0 +1,37 @@
+FROM amazonlinux:2
+
+# This Dockerfile is much lighter but won't work with gke whitelisting. Getting this error when the google gke sdk is called:
+#
+#    Error loading shared library ld-linux-x86-64.so.2: No such file or directory #986
+#
+# If you don't need gke whitelisting, then this image should work and is lighter.
+
+ENV AWS_DEFAULT_REGION "us-east-1"
+
+# https://github.com/sgerrand/alpine-pkg-glibc/releases
+ENV KUBERNETES_VER=1.19.0
+
+RUN amazon-linux-extras install ruby3.0 -y \
+    && amazon-linux-extras install python3.8 -y \
+    && amazon-linux-extras install docker -y
+
+    RUN yum -y install curl wget jq unzip gcc ruby-devel make
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install
+
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VER}/bin/linux/amd64/kubectl
+RUN chmod u+x kubectl && mv kubectl /bin/kubectl
+
+WORKDIR /app
+ADD . /app
+RUN bundle install
+RUN rake install
+
+RUN yum -y remove wget jq unzip gcc ruby-devel make
+RUN yum -y autoremove
+RUN yum clean all && rm -rf /var/cache/yum
+
+
+ENTRYPOINT ["/usr/local/bundle/bin/kubes"]


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* added a base gitlab-ci pipeline to support a generic build and upload to a GitLab Docker image repository; useful for cases where mirroring the repository and automatically publishing images to a private Docker Image Repository to avoid docker hub rate limiting.
* add a docker build file to support AWS ECR scanning as well as AWS Deployments using Kubes

## How to Test
On a machine with docker installed and at the root of the kubes repository run
`docker build --platform linux/amd64 -t kubes:latest -f $PWD/Dockerfile.amazon2 .`

## Version Changes

I would suggest a "patch" version change as there are no changes to the application but supporting workflows to support build processes for AWS and Gitlab.
