### PR TITLE
add role all layer to pre_layers

### DIFF
--- a/docs/_docs/intro/structure.md
+++ b/docs/_docs/intro/structure.md
@@ -34,10 +34,10 @@ Here's what a .kubes folder structure can look like this:
 
 Name | Description
 --- | ---
-base | The base folder is processed first and can be used to define common fields and resources. Learn more on the [Layering Docs]({% link _docs/layering.md %}).
 config | The config folder can be used to configure behavior of Kubes.  The [docker]({% link _docs/config/docker.md %}) config is used to customize the docker command. The [env]({% link _docs/config/env.md %}) config is used to override `config.rb` settings on a `KUBES_ENV` basis. The [kubectl]({% link _docs/config/kubectl.md %}) config is used to customize the kubectl command.
 config.rb | The main thing to configure here is the repo to push the docker image to.
 output | Where kubes builds and writes the Kubernetes YAML to.
 resources | Where you define your Kubernetes resources.
-shared | The shared folder is where you can put shared resources. This folder gets applied first. More info: [Ordering]({% link _docs/intro/ordering.md %}).
+resources/base | The base folder is processed first and can be used to define common fields and resources. Learn more on the [Layering Docs]({% link _docs/layering.md %}).
+resources/shared | The shared folder is where you can put shared resources. This folder gets applied first. More info: [Ordering]({% link _docs/intro/ordering.md %}).
 state | Temporary state info that stores the built Docker image name.

--- a/docs/_includes/layering/layers.md
+++ b/docs/_includes/layering/layers.md
@@ -11,6 +11,7 @@ Here's an example structure, so we can understand how layering works.
     ├── clock
     │   └── deployment.{{ include.ext }}
     └── web
+        ├── all.{{ include.ext }}
         ├── deployment
         │   ├── dev.{{ include.ext }}
         │   └── prod.{{ include.ext }}
@@ -34,16 +35,17 @@ Notes
 
 Here's a table showing the the full layering.
 
-Folder/Pattern     | Example
--------------------|--------------------------------------------
-base/all.{{ include.ext }}       | base/all.{{ include.ext }}
-base/all/ENV.{{ include.ext }}   | base/all/dev.{{ include.ext }}
-base/KIND.{{ include.ext }}      | base/deployment.{{ include.ext }}
-base/KIND/base.{{ include.ext }} | base/deployment/base.{{ include.ext }}
-base/KIND/ENV.{{ include.ext }}  | base/deployment/dev.{{ include.ext }}
-ROLE/KIND.{{ include.ext }}      | web/deployment.{{ include.ext }}
-ROLE/KIND/base.{{ include.ext }} | web/deployment/base.{{ include.ext }}
-ROLE/KIND/ENV.{{ include.ext }}  | web/deployment/dev.{{ include.ext }}
+Type | Folder/Pattern | Example
+---|---|---
+pre | base/all.{{ include.ext }}        | base/all.{{ include.ext }}
+pre | base/all/ENV.{{ include.ext }}    | base/all/dev.{{ include.ext }}
+pre | base/KIND.{{ include.ext }}       | base/deployment.{{ include.ext }}
+pre | base/KIND/base.{{ include.ext }}  | base/deployment/base.{{ include.ext }}
+pre | base/KIND/ENV.{{ include.ext }}   | base/deployment/dev.{{ include.ext }}
+pre | ROLE/all.{{ include.ext }}        | web/all.{{ include.ext }}
+main | ROLE/KIND.{{ include.ext }}      | web/deployment.{{ include.ext }}
+post | ROLE/KIND/base.{{ include.ext }} | web/deployment/base.{{ include.ext }}
+post | ROLE/KIND/ENV.{{ include.ext }}  | web/deployment/dev.{{ include.ext }}
 
 ## Real-World Uses
 

--- a/lib/kubes/compiler/layering.rb
+++ b/lib/kubes/compiler/layering.rb
@@ -6,27 +6,19 @@ class Kubes::Compiler
       ext = File.extname(@path)
       kind = File.basename(@path).sub(ext,'') # IE: deployment
       kind = kind.pluralize if @block_form
+      role = @path.split('/')[-2] # .kubes/resources/web/deployment.yaml
       layers = [
-        "all",
-        "all/#{Kubes.env}",
-        "#{kind}",
-        "#{kind}/#{Kubes.env}",
+        "base/all",
+        "base/all/#{Kubes.env}",
+        "base/#{kind}",
+        "base/#{kind}/#{Kubes.env}",
+        "#{role}/all",
       ]
       layers = add_exts(layers)
       layers.map! do |layer|
-        "#{Kubes.root}/.kubes/resources/base/#{layer}"
+        "#{Kubes.root}/.kubes/resources/#{layer}"
       end
       layers.select { |layer| File.exist?(layer) }
-    end
-
-    def add_exts(layers)
-      layers.map do |layer|
-        [
-          "#{layer}.rb",
-          "#{layer}.yaml",
-          "#{layer}.yml",
-        ]
-      end.flatten
     end
 
     def post_layers
@@ -44,6 +36,16 @@ class Kubes::Compiler
         "#{kind_path}/#{layer}"
       end
       layers.select { |layer| File.exist?(layer) }
+    end
+
+    def add_exts(*layers)
+      layers.flatten.map do |layer|
+        [
+          "#{layer}.rb",
+          "#{layer}.yaml",
+          "#{layer}.yml",
+        ]
+      end.flatten
     end
   end
 end

--- a/lib/kubes/util/consider.rb
+++ b/lib/kubes/util/consider.rb
@@ -3,8 +3,8 @@ module Kubes::Util
     def consider?(path)
       File.file?(path) &&
       !path.include?('/resources/base') &&
-      !path.include?('/base.yaml') &&
-      !path.include?('/base.yml')
+      !path.include?('/base.') &&
+      !path.include?('/all.')
     end
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add a role-based all layer. IE:

    .kubes/web/all.yaml

This will be applied to all the web roles. IE:

    .kubes/web/deployment.yaml
    .kubes/web/service.yaml
    .kubes/web/ingress.yaml

## How to Test

* Deploy kubes demo project for sanity check
* Add a `.kubes/web/all.yaml`, run `kubes apply`, and confirm that the layer gets merged.

## Version Changes

Patch