### PR TITLE
Fix Checksum Hash when element not first item

### DIFF
--- a/lib/kubes/compiler/decorator/hashable/field.rb
+++ b/lib/kubes/compiler/decorator/hashable/field.rb
@@ -1,53 +1,72 @@
 class Kubes::Compiler::Decorator::Hashable
   class Field
-    # item is full wrapper structure
+    # item is full structure
     #
-    #     secretRef:  <--- wrapper
-    #       name: demo-secret
+    #     secretRef:           <--- wrapper_key
+    #       name: demo-secret  <--- target_key is 'name' from wrapper_map[wrapper_key]
     #
+    attr_reader :item # for debugging
     def initialize(item)
       @item = item
     end
 
     def hashable?
-      x = @item.keys & map.keys
+      x = @item.keys & wrapper_map.keys
       !x.empty?
     end
 
     def kind
-      wrapper =~ /configMap/ ? "ConfigMap" : "Secret"
+      wrapper_key =~ /configMap/ ? "ConfigMap" : "Secret"
     end
 
-    # The key of the hashable value.
+    # The target key of the hashable value is that key used for find value to add hash
     #
     #     envFrom:
-    #     - secretRef:
-    #         name: demo-secret    <--- wrapper is 'name'
+    #     - secretRef:             <--- wrapper_key
+    #         name: demo-secret    <--- target_key is 'name' from wrapper_map[wrapper_key]
     #
-    def key
-      map[wrapper]
+    def target_key
+      wrapper_map[wrapper_key]
     end
 
     # The wrapper field is nested right above the item with the hashable value.
+    # Simple example:
     #
     #     envFrom:
-    #     - secretRef:  <--- wrapper
-    #         name: demo-secret
+    #     - secretRef:           <--- wrapper_key
+    #         name: demo-secret  <--- target_key is 'name' from wrapper_map[wrapper_key]
     #
-    def wrapper
-      @item.keys.first
+    # More complex example where there's a configMap.name key also on the same level.
+    #
+    #     volumes:
+    #     - name: config-map-volume
+    #       configMap:
+    #         name: demo-config-map
+    #
+    # Note: Wont work for case when there's are 2 matching wrapper_map keys,
+    # but don't think Kubernetes allows 2 matching wrapper_map keys.
+    # Example: This is invalid Kubernetes YAML.
+    #
+    #     volumes:
+    #     - name: config-map-volume
+    #       configMap:
+    #         name: demo-config-map
+    #       secretRef:
+    #         name: demo-seret
+    def wrapper_key
+      @item.keys.find { |k| wrapper_map.keys.include?(k) } # this key used for map[wrapper_key]
     end
 
     # wrapper element to key that stores the hashable value
-    def map
+    def wrapper_map
       {
-        'configMapRef' => 'name',
-        'configMapKeyRef' => 'name',
-        'configMap' => 'name',
-        'secretRef' => 'name',
-        'secretKeyRef' => 'name',
-        'secret' => 'secretName',
-        'tls' => 'secretName',
+        'configMapRef' => 'name',    # containers.env.envFrom.configMapRef.name
+        'configMapKeyRef' => 'name', # containers.env.valueFrom.configMapKeyRef.name
+        'configMap' => 'name',       # containers.env.envFrom.configMapRef.name
+        'secretRef' => 'name',       # containers.env.envFrom.secretRef.name
+        'secretKeyRef' => 'name',    # containers.env.valueFrom.secretKeyRef.name
+        'secret' => 'secretName',    # volumes.secret.secretName
+        'tls' => 'secretName',       # tls.secretName
       }
     end
   end

--- a/spec/fixtures/decorators/deployment/configMap/volumes-name-first.yaml
+++ b/spec/fixtures/decorators/deployment/configMap/volumes-name-first.yaml
@@ -1,0 +1,14 @@
+---
+# apiVersion: apps/v1
+# kind: Deployment
+# spec:
+#   template:
+#     spec:
+# only including structure needed for spec
+volumes:
+- name: config-map-volume
+  configMap:
+    name: demo-config-map
+    items:
+    - key: k1
+      path: config-map.conf

--- a/spec/fixtures/decorators/deployment/configMap/volumes-name-second.yaml
+++ b/spec/fixtures/decorators/deployment/configMap/volumes-name-second.yaml
@@ -1,0 +1,14 @@
+---
+# apiVersion: apps/v1
+# kind: Deployment
+# spec:
+#   template:
+#     spec:
+# only including structure needed for spec
+volumes:
+- configMap:
+    name: demo-config-map
+    items:
+    - key: k1
+      path: config-map.conf
+  name: config-map-volume

--- a/spec/fixtures/decorators/ingress/tls.yaml
+++ b/spec/fixtures/decorators/ingress/tls.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+spec:
+  tls:
+  - secretName: tls-secret
+  defaultBackend:
+    service:
+      name: web
+      port:
+        number: 80

--- a/spec/kubes/compiler/decorator/post/deployment_spec.rb
+++ b/spec/kubes/compiler/decorator/post/deployment_spec.rb
@@ -135,4 +135,29 @@ describe Kubes::Compiler::Decorator::Post do
       end
     end
   end
+
+  context "order" do
+    # spec to fix issue TODO: add issue number
+    describe "name first" do
+      let(:data) { fixture("configMap/volumes-name-first") }
+      it "run" do
+        decorator.run
+        data = decorator.data
+        volumes = data['volumes']
+        name = volumes[0]['configMap']['name']
+        expect(name).to eq("demo-config-map-fakehash-config")
+      end
+    end
+
+    describe "name second" do
+      let(:data) { fixture("configMap/volumes-name-second") }
+      it "run" do
+        decorator.run
+        data = decorator.data
+        volumes = data['volumes']
+        name = volumes[0]['configMap']['name']
+        expect(name).to eq("demo-config-map-fakehash-config")
+      end
+    end
+  end
 end

--- a/spec/kubes/compiler/decorator/post/ingress_spec.rb
+++ b/spec/kubes/compiler/decorator/post/ingress_spec.rb
@@ -1,0 +1,22 @@
+describe Kubes::Compiler::Decorator::Post do
+  let(:decorator) { described_class.new(data) }
+
+  def fixture(name)
+    YAML.load_file("spec/fixtures/decorators/ingress/#{name}.yaml")
+  end
+  before(:each) do
+    allow(Kubes::Compiler::Decorator::Hashable::Storage).to receive(:fetch).and_return("fakehash")
+  end
+
+  context "ingress" do
+    describe "tls" do
+      let(:data) { fixture("tls") }
+      it "run" do
+        decorator.run
+        data = decorator.data
+        name = data['spec']['tls'][0]['secretName']
+        expect(name).to eq("tls-secret-fakehash")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes #49

## Context

#49

## How to Test

Snippet of YAML to reproduce problem:

```yaml
---
apiVersion: apps/v1
kind: Deployment
spec:
  # ...
  template:
    spec:
      volumes:
      - name: demo-config-map
        configMap:
          name: demo-config-map
```

Run:

    kubes compile

Will produce something like this:

```yaml
---
spec:
  # ...
  template:
    spec:
      - name: demo-config-map
        configMap:
          name: demo-config-map-4750b55769 # <-- Notice the checksum. 
apiVersion: apps/v1
kind: Deployment
```

Before the checksum was not be added unless configMap was the first element in the Array.


## Version Changes

Patch