### PR TITLE
make helper methods available in variables files

### DIFF
--- a/lib/kubes/compiler/shared/runtime_helpers.rb
+++ b/lib/kubes/compiler/shared/runtime_helpers.rb
@@ -3,9 +3,9 @@ module Kubes::Compiler::Shared
     include Kubes::Compiler::Shared::Helpers
 
     def load_runtime_helpers
-      load_custom_variables # also load custom variables
       load_plugin_helpers
       load_custom_helpers
+      load_custom_variables # also load custom variables
     end
 
     @@custom_helpers_loaded = false


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Load custom variables last so helpers are available in variables files https://kubes.guru/docs/variables/basic/

## Context

Would be nice to be able to access helpers like [google_secret](https://kubes.guru/docs/helpers/google/secrets/) in variables files and keep templates simpler with only variables.

## How to Test

.kubes/variables/dev.rb

```ruby
@cert = google_secret("cert-demo-global", base64: false)
```

.kubes/resources/web/ingress.yaml

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: web
  annotations:
    ingress.gcp.kubernetes.io/pre-shared-cert: '<%= @cert %>'
spec:
  defaultBackend:
    service:
      name: web
      port:
        number: 80
```

## Version Changes

Patch