### PR TITLE
Fix activesupport require

### DIFF
--- a/lib/kubes.rb
+++ b/lib/kubes.rb
@@ -5,6 +5,7 @@ $:.unshift(File.expand_path("../", __FILE__))
 require "kubes/autoloader"
 Kubes::Autoloader.setup
 
+require "active_support"
 require "active_support/core_ext/class"
 require "active_support/core_ext/hash"
 require "active_support/core_ext/string"


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix activesupport require

## Context

* https://github.com/boltops-tools/terraspace/pull/164
* https://github.com/boltops-tools/ufo/pull/122
* https://github.com/boltops-tools/cody/pull/32

## How to Test

Run any kubes command. IE: `kubes compile`

## Version Changes

Patch