### PR TITLE
central deployer support

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "html-proofer"
 gem "jekyll"
+gem "jekyll-include-cache"
 gem "opal"
 gem "opal-browser"
 gem "opal-jquery"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -70,4 +70,10 @@ defaults:
 plugins_dir:
   # - jekyll-gzip - GitHub pages does not support this plugin.
 
+# List of supported plugins:
+# https://pages.github.com/versions.json
+# https://github.com/github/pages-gem/issues/171
+plugins:
+- jekyll-include-cache # Supported by GitHub pages
+
 ads_url: "https://ads.boltops.com"

--- a/docs/_docs/config/app-overrides.md
+++ b/docs/_docs/config/app-overrides.md
@@ -1,0 +1,7 @@
+---
+title: App Overrides Cheatsheet
+---
+
+Kubes supports app-level overrides. This is especially useful for the [Central Deployer Pattern]({% link _docs/patterns/central-deployer.md %}).
+
+{% include config/app-overrides-cheatsheet.md %}

--- a/docs/_docs/config/boot.md
+++ b/docs/_docs/config/boot.md
@@ -1,0 +1,46 @@
+---
+title: Boot Hooks
+---
+
+If you need to hook into the Kubes boot process super-early on, Kubes boot hooks are designed for that.
+
+* They run very early in the Kubes boot process.
+* They are useful for setting shared global values like env vars.
+* Boot hooks are ruby files that get required. It's nice and simple. There's no interface to learn.
+
+## Hooks
+
+Kubes will searches 2 files in the `config` folder. If the files exist, they will be ran in this order.
+
+1. **.kubes/config/boot.rb**: Always runs.
+2. **.kubes/config/boot/KUBES_ENV.rb**: Runs based on the env. IE: `KUBES_ENV=dev` => `.kubes/config/boot/dev.rb`
+
+Both files are required and ran if they both exists. Since the `KUBES_ENV` one runs second, it can be used to override previously set values.
+
+## Example: Default KUBES_ENV
+
+If you prefer a different default than `KUBES_ENV=dev`.
+
+config/boot.rb
+
+```ruby
+ENV['KUBES_ENV'] ||= 'development'
+```
+
+This changes the default for everyone using the project, but still allows them to control the default by adding `export KUBES_ENV=development` to their `~/.bash_profile`.
+
+## Example: Auto-Switch AWS_PROFILE
+
+One useful example is switching `AWS_PROFILE` based on the `KUBES_ENV`. Example:
+
+config/boot/dev.rb
+
+```ruby
+ENV['AWS_PROFILE'] = 'dev'
+```
+
+This example is for AWS, but you can can do similiar switch logic with `GOOGLE_APPLICATION_CREDENTIALS`, etc.
+
+## Boot Source
+
+Please refer to the boot source code for more details: [kubes/booter.rb](https://github.com/boltops-tools/kubes/blob/master/lib/kubes/booter.rb)

--- a/docs/_docs/config/env.md
+++ b/docs/_docs/config/env.md
@@ -16,7 +16,9 @@ Kubes.configure do |config|
 end
 ```
 
-## Layering
+## Config Overrides
+
+### Env Overrides
 
 You can override configs on a per-env basis with `config/env` files. Examples:
 
@@ -38,7 +40,32 @@ Kubes.configure do |config|
 end
 ```
 
-For more details refer to the [Layering Docs]({% link _docs/layering.md %}).
+### App Overrides
+
+If KUBES_APP is set, app-scoped configs can be used to override settings further. Here are some with `config/env/app` example files:
+
+.kubes/config/env/app1/dev.rb
+
+```ruby
+Kubes.configure do |config|
+  config.repo = "222222222222.dkr.ecr.us-west-2.amazonaws.com/demo"
+  config.kubectl.context = "dev-cluster"
+end
+```
+
+.kubes/config/env/app2/prod.rb
+
+```ruby
+Kubes.configure do |config|
+  config.repo = "333333333333.dkr.ecr.us-west-2.amazonaws.com/demo"
+  config.kubectl.context = "prod-cluster"
+end
+```
+
+This allows you to set specific app-level settings with:
+
+    KUBES_APP=app1 kubes deploy
+    KUBES_APP=app2 kubes deploy
 
 ## Auto-Switching Context
 

--- a/docs/_docs/config/reference.md
+++ b/docs/_docs/config/reference.md
@@ -8,7 +8,7 @@ auto_prune | Prune and delete old hashed resources like Secret and ConfigMap. | 
 builder | What docker build command to use. Can use `docker` or `gcloud` to build the Docker image. | docker
 image | Set a prebuilt Docker image to use. This is optional. Usually, you want to build an image from the Dockerfile.  Setting this will change the `docker_image` helper to use a predefined image. See: [Docker Image]({% link _docs/intro/docker-image.md %}) | nil
 kubectl.context | What kubectl context to auto-switch to. | nil
-kubectl.context_keep | Whether or not to keep the context switched | true
+kubectl.context_keep | Whether or not to keep the context switched | false
 kubectl.exit_on_fail.apply  | Whether or not continue if the `kubectl apply` fails. Note, can use `KUBES_EXIT_ON_FAIL=0` env var to set to false. | true
 kubectl.exit_on_fail.delete | Whether or not continue if the `kubectl delete` fails. | false
 kubectl.order.kinds | Change ordering for Kubernetes Kinds. | See [source code](https://github.com/boltops-tools/kubes/blob/master/lib/kubes/config.rb#L52)
@@ -18,6 +18,6 @@ logger.level | Logger level. Can also be set with `KUBES_LOG_LEVEL` env var | in
 repo | The Docker repo to use. Required to be set. | nil
 repo_auto_auth | Whether or not to try to auth authorize docker repo registry if not yet logged in. Can also be set with env var `KUBES_REPO_AUTO_AUTO` | true
 skip | List of resources to skip. Can also be set with the `KUBES_SKIP` env var. `KUBES_SKIP` should be a list of strings separated by spaces. It adds onto the `config.skip` option. | []
-state.path | Where to store the state file with the last build Docker image. | .kubes/state/KUBES_ENV/data.json
+state.path | Where to store the state file with the last build Docker image. | .kubes/state/KUBES_APP/KUBES_ENV/data.json
 suffix_hash | Whether or not to append suffix hash to ConfigMap and Secret | true
 merger.options | Merger options that control how Hashes are merged. More info: [Merger Options]({% link _docs/layering/merge-options.md %}) | `{overwrite_arrays: true}`

--- a/docs/_docs/config/skip.md
+++ b/docs/_docs/config/skip.md
@@ -56,3 +56,25 @@ You can also us ethe `KUBES_SKIP` env var. It takes list of strings separated by
     KUBES_SKIP="cleanup/job" kubes delete
 
 This can be useful for one-off use cases.
+
+## Skip With kubes skip metdata
+
+You can also skip a resource from being written by using `kubes.skip = true`. This is useful if you want to conditionally not create a resource with a variable. Example:
+
+.kubes/resources/config_map.yaml
+
+```yaml
+<% if @skip %>
+kubes:
+  skip: true
+<% end %>
+metadata:
+  namespace: demo-dev
+  labels:
+    app: demo-dev
+  name: demo-dev-configmap-495c18844b
+apiVersion: v1
+kind: ConfigMap
+```
+
+If the variable is set to `@skip = true`, then the config_map.yaml will not get created.

--- a/docs/_docs/patterns/central-deployer.md
+++ b/docs/_docs/patterns/central-deployer.md
@@ -1,0 +1,36 @@
+---
+title: Central Deployer Pattern
+nav_text: Central Deployer
+categories: patterns
+---
+
+Kubes can be use as either an app-centric or ops-centric tool.
+
+* **app-centric**: Each app repo has it's own `.kubes` settings files. This is useful if your applications are very differently setup.
+* **ops-centric**: Each app repo has pretty much the same `.kubes` settings files. This is useful if your applications are very similarly setup.
+
+## Setup
+
+With an ops-centric approach, you use the same `.kubes` settings files for the app repos you want to use. For example:
+
+    https://github.com/repo/app1
+    https://github.com/repo/app2
+
+You then also have a
+
+    https://github.com/repo/.kubes
+
+You can simply copy the `.kubes` folder into the app repo folder or even add the `repo/.kubes` as a submodule.
+
+You'll end up with something like this:
+
+    app1/.kubes
+    app2/.kubes
+
+Then to deploy different app level settings.
+
+{% include config/app-overrides-cheatsheet.md %}
+
+The central deployer approach is removes duplication of the kubes config files between projects. Leveraging app-level overrides gives provides a great degree of control.
+
+If the settings start to diverge too much, then it probably makes sense to use separate .kubes files in that app specific repo.

--- a/docs/_docs/variables/advanced.md
+++ b/docs/_docs/variables/advanced.md
@@ -2,6 +2,7 @@
 title: Advanced Variables
 nav_text: Advanced
 categories: variables
+order: 2
 ---
 
 Basic variables layering should provides enough flexibility and is generally recommended. This page  covers more advanced variables layering.
@@ -44,12 +45,26 @@ And when `KUBES_ENV=prod`:
 
 With advanced layering you can target a specific role and kind. So variables are only scoped to the resources you want.
 
+## App-Level Overrides
+
+If KUBES_APP is set, then app level layer overrides will also be processed. Example:
+
+    KUBES_APP=app1 kubes deploy
+
+Here's an example with some of the additional files that get layered:
+
+    .kubes/variables/app1.rb
+    .kubes/variables/app1/base.rb
+    .kubes/variables/app1/dev.rb
+
+This is useful if you're using kubes as part of a central deployer pattern. For the full list of layers refer to the table below:
+
 ## Full Layering Table
 
 Here's a table showing the the full layering.
 
 Folder/Pattern    | Example
-------------------|--------------------------------------------
+------------------|----------------------------
 base.rb           | base.rb
 ENV.rb            | dev.rb
 base/all.rb       | base/all.rb
@@ -60,5 +75,21 @@ base/KIND/ENV.rb  | base/deployment/dev.rb
 ROLE/KIND.rb      | web/deployment.rb
 ROLE/KIND/base.rb | web/deployment/base.rb
 ROLE/KIND/ENV.rb  | web/deployment/dev.rb
+
+If KUBES_APP is set then these additional layers are also processed:
+
+Folder/Pattern    | Example
+------------------|----------------------------
+APP.rb           | app1.rb
+APP/base.rb           | app1/base.rb
+APP/ENV.rb            | app1/dev.rb
+APP/base/all.rb       | app1/base/all.rb
+APP/base/all/ENV.rb   | app1/base/all/dev.rb
+APP/base/KIND.rb      | app1/base/deployment.rb
+APP/base/KIND/base.rb | app1/base/deployment/base.rb
+APP/base/KIND/ENV.rb  | app1/base/deployment/dev.rb
+APP/ROLE/KIND.rb      | app1/web/deployment.rb
+APP/ROLE/KIND/base.rb | app1/web/deployment/base.rb
+APP/ROLE/KIND/ENV.rb  | app1/web/deployment/dev.rb
 
 {% include variables/generator.md %}

--- a/docs/_docs/variables/basic.md
+++ b/docs/_docs/variables/basic.md
@@ -2,6 +2,7 @@
 title: Basic Variables
 nav_text: Basic
 categories: variables
+order: 1
 ---
 
 ## Basic Layering Example

--- a/docs/_docs/yaml/erb-comment.md
+++ b/docs/_docs/yaml/erb-comment.md
@@ -1,0 +1,89 @@
+---
+title: ERB Comment Syntax PreProcessor
+---
+
+Kubes allows you build kubernetes resources by compiling down `.kubes/resources` files with ERB.  This is a powerful ability, but it can get in the way of IDE kubernetes autocompletion tools.
+
+## Pre-Processing Before ERB
+
+To work with IDE kubernetes autocompletion tools, kubes supports a lighter ERB comment-based syntax. It looks like this:
+
+.kubes/resources/web/service.yaml
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    name: web
+#ERB if @role_label
+    role: #ERB= @role_label
+#ERB end
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: <%= dockerfile_port %>
+  selector:
+    role: web
+  type: ClusterIP
+```
+
+This allows IDB kubernetes autocompletion plugins and tools to work because the `.kubes/resources/web/service.yaml` source code itself is perfectly valid YAML.
+
+The `#ERB` comments are essentially replaced by `<% ... %>` tags before ERB processing happens. Example:
+
+.kubes/resources/web/service.yaml.erb
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    name: web
+<% if @role_label %>
+    role: <%= @role_label %>
+<% end %>
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: <%= dockerfile_port %>
+  selector:
+    role: web
+  type: ClusterIP
+```
+
+If you need to keep around the generated `.erb` file for debugging, use the `KUBES_KEEP_ERB` env var. Example:
+
+    $ KUBES_KEEP_ERB=1 kubes compile
+    .kubes/resources/web/service.yaml.erb  # kept around
+
+## Multiple Line ERB Comment Syntax
+
+The ERB Comment syntax works because kubes simply replaces each line with actual ERB. For multiple line ERB syntax:
+
+.kubes/resources/web/service.yaml
+
+```yaml
+#ERB if Kubes.env == "dev"
+#ERB   env_label = "development"
+#ERB end
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    name: web
+    env: #ERB= env_label
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: <%= dockerfile_port %>
+  selector:
+    role: web
+  type: ClusterIP
+```

--- a/docs/_includes/config/app-overrides-cheatsheet.md
+++ b/docs/_includes/config/app-overrides-cheatsheet.md
@@ -1,0 +1,44 @@
+## App-Level Specific Settings
+
+You can override all the different settings at the app-level when KUBES_APP is set.
+
+For app1:
+
+    cd app1
+    KUBES_APP=app1 kubes deploy
+
+And for app2:
+
+    cd app2
+    KUBES_APP=app2 kubes deploy
+
+## Config Env
+
+Override `config/app.rb` with app-level settings like so:
+
+    .kubes/config/env/app1/base.rb
+    .kubes/config/env/app1/dev.rb
+    .kubes/config/env/app1/prod.rb
+    .kubes/config/env/app2/base.rb
+    .kubes/config/env/app2/dev.rb
+    .kubes/config/env/app2/prod.rb
+
+## Variables
+
+Override `.kubes/variables/base.rb`, `.kubes/variables/dev.rb` etc like so:
+
+    .kubes/variables/app1/base.rb
+    .kubes/variables/app1/dev.rb
+    .kubes/variables/app1/prod.rb
+    .kubes/variables/app2/base.rb
+    .kubes/variables/app2/dev.rb
+    .kubes/variables/app2/prod.rb
+
+## Resources
+
+Override resources like so:
+
+    .kubes/resources/shared/config_map/app1.yaml
+    .kubes/resources/shared/config_map/app2.yaml
+    .kubes/resources/shared/secret/app1.yaml
+    .kubes/resources/shared/secret/app2.yaml

--- a/docs/_includes/content.html
+++ b/docs/_includes/content.html
@@ -5,7 +5,7 @@
 {% else %}
 
 <div class="d-flex" id="wrapper">
-  {% include sidebar.html %}
+  {% include_cached sidebar.html %}
   <div id="content">
     <div class="menu-top-bar">
       <div id="menu-toggle">

--- a/docs/_includes/layering/layers.md
+++ b/docs/_includes/layering/layers.md
@@ -46,6 +46,9 @@ pre | ROLE/all.{{ include.ext }}        | web/all.{{ include.ext }}
 main | ROLE/KIND.{{ include.ext }}      | web/deployment.{{ include.ext }}
 post | ROLE/KIND/base.{{ include.ext }} | web/deployment/base.{{ include.ext }}
 post | ROLE/KIND/ENV.{{ include.ext }}  | web/deployment/dev.{{ include.ext }}
+post | ROLE/KIND/APP.{{ include.ext }} | web/deployment/app1.{{ include.ext }}
+post | ROLE/KIND/APP/base.{{ include.ext }} | web/deployment/app1/base.{{ include.ext }}
+post | ROLE/KIND/APP/ENV.{{ include.ext }}  | web/deployment/app1/dev.{{ include.ext }}
 
 ## Real-World Uses
 

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -100,10 +100,12 @@
             {% endfor %}
             </ul>
           </li>
+          <li><a href="{% link _docs/config/boot.md %}">Boot Hooks</a></li>
           <li><a href="{% link _docs/config/docker.md %}">Docker</a></li>
           <li><a href="{% link _docs/config/env.md %}">Env</a></li>
           <li><a href="{% link _docs/config/builder.md %}">Builder</a></li>
           <li><a href="{% link _docs/config/skip.md %}">Skip Option</a></li>
+          <li><a href="{% link _docs/config/app-overrides.md %}">App Overrides</a></li>
           <li><a href="{% link _docs/config/reference.md %}">Reference</a></li>
         </ul>
       </li>
@@ -112,6 +114,7 @@
         <ul>
           <li><a href="{% link _docs/yaml/multiple-resources.md %}">Multiple Resources</a></li>
           <li><a href="{% link _docs/yaml/multiple-files.md %}">Multiple Files</a></li>
+          <li><a href="{% link _docs/yaml/erb-comment.md %}">ERB Comment Syntax</a></li>
         </ul>
       </li>
       <li><a href="{% link _docs/layering.md %}">Layering</a>
@@ -138,7 +141,7 @@
       </li>
       <li><a href="{% link _docs/variables.md %}">Variables</a>
         <ul>
-          {% assign docs = site.docs | where: "categories","variables" %}
+          {% assign docs = site.docs | where: "categories","variables" | sort:"order" %}
           {% for doc in docs -%}
             <li><a href="{{ doc.url }}">{{ doc.nav_text }}</a></li>
           {% endfor %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -24,6 +24,7 @@
   <script src="/vendor/jquery/jquery.min.js"></script>
   <script src="/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
   <script src="/js/app.js"></script>
+  <script src="/js/scripts.js"></script>
 </head>
 
 <body>

--- a/docs/js/scripts.js
+++ b/docs/js/scripts.js
@@ -1,0 +1,7 @@
+$(document).ready(function() {
+  // adjust edit-page link
+  var github_base = $('#edit-page').attr('href');
+  var md_page = window.location.pathname.replace('/','_').replace(/\/$/,'.md');
+  var href = github_base + md_page;
+  $('#edit-page').attr('href', href);
+});

--- a/lib/kubes.rb
+++ b/lib/kubes.rb
@@ -31,3 +31,5 @@ module Kubes
   class MissingDockerImage < Error; end
   extend Core
 end
+
+Kubes::Booter.boot

--- a/lib/kubes/booter.rb
+++ b/lib/kubes/booter.rb
@@ -1,0 +1,26 @@
+module Kubes
+  module Booter
+    def boot
+      run_hooks
+    end
+
+    # Special boot hooks run super early, even before plugins are loaded.
+    # Useful for setting env vars and other early things.
+    #
+    #    config/boot.rb
+    #    config/boot/dev.rb
+    #
+    def run_hooks
+      run_hook
+      run_hook(Kubes.env)
+    end
+
+    def run_hook(env=nil)
+      name = env ? "boot/#{env}" : "boot"
+      path = "#{Kubes.root}/.kubes/#{name}.rb"
+      require path if File.exist?(path)
+    end
+
+    extend self
+  end
+end

--- a/lib/kubes/cli/init.rb
+++ b/lib/kubes/cli/init.rb
@@ -85,7 +85,6 @@ class Kubes::CLI
     def adjust_gitignore
       ignores = %w[
         .kubes/output
-        .kubes/state
         .kubes/tmp
       ].map {|l| "#{l}\n"} # the readlines will have lines with \n so keep consistent for processing
       if File.exist?(".gitignore")

--- a/lib/kubes/compiler.rb
+++ b/lib/kubes/compiler.rb
@@ -38,6 +38,8 @@ module Kubes
     end
 
     def write(result)
+      return if config_skip?(result.filename)
+      return if result.skip?
       result.decorate!(:post)
       filename, content = result.filename, result.content
       dest = "#{Kubes.root}/.kubes/output/#{filename}"

--- a/lib/kubes/compiler/layering.rb
+++ b/lib/kubes/compiler/layering.rb
@@ -31,6 +31,15 @@ class Kubes::Compiler
         "base",
         Kubes.env.to_s
       ]
+
+      if Kubes.app
+        layers += [
+          Kubes.app,
+          "#{Kubes.app}/base",
+          "#{Kubes.app}/#{Kubes.env}",
+        ]
+      end
+
       layers = add_exts(layers)
       layers.map! do |layer|
         "#{kind_path}/#{layer}"

--- a/lib/kubes/compiler/shared/runtime_helpers.rb
+++ b/lib/kubes/compiler/shared/runtime_helpers.rb
@@ -68,6 +68,13 @@ module Kubes::Compiler::Shared
         "#{role}/#{kind}/base.rb",
         "#{role}/#{kind}/#{Kubes.env}.rb",
       ]
+      if Kubes.app
+        app_layers = ["#{Kubes.app}.rb"]
+        app_layers += layers.map do |path|
+          "#{Kubes.app}/#{path}"
+        end
+        layers += app_layers
+      end
 
       layers.each do |layer|
         path = "#{Kubes.root}/.kubes/variables/#{layer}"

--- a/lib/kubes/compiler/strategy/erb.rb
+++ b/lib/kubes/compiler/strategy/erb.rb
@@ -17,7 +17,11 @@ class Kubes::Compiler::Strategy
     def render_result(path)
       return unless File.exist?(path)
 
+      comment = Comment.new(path)
+      path = comment.process if comment.process?
       yaml = RenderMePretty.result(path, context: self)
+      comment.clean if comment.process?
+
       result = yaml_load(path, yaml)
       # in case of blank yaml doc a Boolean false is returned. else Hash or Array is returned
       %w[Array Hash].include?(result.class.to_s) ? result : {}

--- a/lib/kubes/compiler/strategy/erb/comment.rb
+++ b/lib/kubes/compiler/strategy/erb/comment.rb
@@ -1,0 +1,46 @@
+# Processes the ERB files and looks for comments like
+#
+#     #ERB if @testvar
+#     - "some yaml"
+#     #ERB end
+#
+class Kubes::Compiler::Strategy::Erb
+  class Comment
+    extend Memoist
+
+    def initialize(path)
+      @path = path
+    end
+
+    def lines
+      IO.readlines(@path)
+    end
+    memoize :lines
+
+    def process?
+      !!lines.detect { |l| l.include?('#ERB') }
+    end
+
+    def process
+      new_lines = lines.map do |line|
+        md = line.match(/(.*)#ERB(.*)/)
+        if md
+          "#{md[1]}<%#{md[2]} %>\n"
+        else
+          line
+        end
+      end
+      content = new_lines.join('')
+      IO.write(erb_path, content)
+      erb_path
+    end
+
+    def clean
+      FileUtils.rm_f(erb_path) unless ENV['KUBES_KEEP_ERB']
+    end
+
+    def erb_path
+      "#{@path}.erb"
+    end
+  end
+end

--- a/lib/kubes/compiler/strategy/result.rb
+++ b/lib/kubes/compiler/strategy/result.rb
@@ -21,8 +21,20 @@ class Kubes::Compiler::Strategy
     end
 
     def content
-      result = @data.size == 1 ? @data.first : @data
+      data = filter_skip(@data)
+      return if data.empty?
+      result = data.size == 1 ? data.first : data
       yaml_dump(result)
+    end
+
+    def skip?
+      content.nil?
+    end
+
+    def filter_skip(data)
+      data.reject do |item|
+        item.dig('kubes', 'skip')
+      end
     end
   end
 end

--- a/lib/kubes/config.rb
+++ b/lib/kubes/config.rb
@@ -18,7 +18,7 @@ module Kubes
       # Auto-switching options
       config.kubectl = ActiveSupport::OrderedOptions.new
       config.kubectl.context = nil
-      config.kubectl.context_keep = true # after switching context keep it
+      config.kubectl.context_keep = false # after switching context keep it
 
       # whether or not continue if the kubectl command fails
       config.kubectl.exit_on_fail = ActiveSupport::OrderedOptions.new
@@ -39,7 +39,7 @@ module Kubes
       config.skip = []
 
       config.state = ActiveSupport::OrderedOptions.new
-      config.state.path = "#{Kubes.root}/.kubes/state/#{Kubes.env}/data.json"
+      config.state.path = ["#{Kubes.root}/.kubes/tmp/state", Kubes.app, "#{Kubes.env}/data.json"].compact.join('/')
 
       config.suffix_hash = true # append suffix hash to ConfigMap and Secret
 
@@ -95,6 +95,10 @@ module Kubes
     def load_configs
       evaluate_file(".kubes/config.rb")
       evaluate_file(".kubes/config/env/#{Kubes.env}.rb")
+      if Kubes.app
+        evaluate_file(".kubes/config/env/#{Kubes.app}.rb")
+        evaluate_file(".kubes/config/env/#{Kubes.app}/#{Kubes.env}.rb")
+      end
       Kubes::Plugin.plugins.each do |klass|
         # klass: IE: KubesAws, KubesGoogle
         name = klass.to_s.underscore.sub('kubes_','') # kubes_google => google

--- a/lib/kubes/core.rb
+++ b/lib/kubes/core.rb
@@ -2,6 +2,10 @@ module Kubes
   module Core
     extend Memoist
 
+    def app
+      ENV['KUBES_APP']
+    end
+
     def env
       ENV['KUBES_ENV'] || "dev"
     end

--- a/lib/kubes/kubectl/ordering.rb
+++ b/lib/kubes/kubectl/ordering.rb
@@ -13,18 +13,21 @@ class Kubes::Kubectl
         "#{role_i}/#{kind_i}"
       end
 
-      sorted = filter_files(sorted)
+      sorted = filter_skip(sorted)
 
       @name == "delete" ? sorted.reverse : sorted
     end
 
-    def filter_files(sorted)
+    def filter_skip(sorted)
+      sorted.reject do |file|
+        config_skip?(file)
+      end
+    end
+
+    def config_skip?(file)
       skip = Kubes.config.skip
       skip += ENV['KUBES_SKIP'].split(' ') if ENV['KUBES_SKIP']
-      return sorted if skip.empty?
-      sorted.reject do |file|
-        skip.detect { |text| file.include?(text) }
-      end
+      !!skip.detect { |pattern| file.include?(pattern) }
     end
 
     # type: kinds or roles


### PR DESCRIPTION
* Kubes.app concept
* early boot hook
* app-level overrides support: config/env, variables, resources
* config.kubectl.context_keep = false
* dont write config skip files
* erb comment preprocessor
* kubes.skip metadata ability
* use .kubes/tmp/state to reduce ignored folders
* speed up docs build

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Introduce Kubes.app concept to support the central deployer pattern.

## Context

Requested by user.

## How to Test

Try out example in docs:

    KUBES_APP=app1 kubes deploy
    KUBES_APP=app2 kubes deploy

## Version Changes

Minor