### PR TITLE
add erb support for config_map_files and generic_secret_data helpers

### DIFF
--- a/lib/kubes/compiler/shared/helpers/config_map_helper.rb
+++ b/lib/kubes/compiler/shared/helpers/config_map_helper.rb
@@ -18,9 +18,10 @@ module Kubes::Compiler::Shared::Helpers
       data = {}
       layers.each do |path|
         next unless File.exist?(path)
-        lines = IO.readlines(path)
+        text = RenderMePretty.result(path, context: self)
+        lines = text.split("\n")
         lines.each do |line|
-          key, value = line.split('=').map(&:strip)
+          key, value = parse_env_like_line(line)
           data[key] = value
         end
       end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* Add ERB support for `config_map_files` and `generic_secret_data` helpers.  
* Improve env-like files parsing

## Context

Related #60 

## How to Test

Go through the examples on the docs.

* https://kubes.guru/docs/helpers/builtin/config-map-files/
* https://kubes.guru/docs/helpers/google/secret_data/
* https://kubes.guru/docs/helpers/aws/secret_data/

## Version Changes

Patch