### PR TITLE
remove kubes meta from yaml

### DIFF
--- a/lib/kubes/compiler/strategy/result.rb
+++ b/lib/kubes/compiler/strategy/result.rb
@@ -22,6 +22,7 @@ class Kubes::Compiler::Strategy
 
     def content
       data = filter_skip(@data)
+      data.each { |item| item.delete('kubes') }
       return if data.empty?
       result = data.size == 1 ? data.first : data
       yaml_dump(result)


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The `kubes` key can be use as a way to provide meta data specific to kubes like skipping creating of the resource entirely: https://kubes.guru/docs/config/skip/#skip-with-kubes-skip-metdata

This PR removes the kubes metadata section.

## Context

Trying to use:

```yaml
kubes:
  skip: true
```

## How to Test

deploy a simple app:

    kubes deploy

## Version Changes

Patch