### PR TITLE
show layering improvements: show resource layers also

### DIFF
--- a/lib/kubes/compiler/strategy/dispatcher.rb
+++ b/lib/kubes/compiler/strategy/dispatcher.rb
@@ -1,7 +1,7 @@
 class Kubes::Compiler::Strategy
   class Dispatcher < Base
     def dispatch
-      logger.info "Compiling #{pretty_path(@path)}" if Kubes.config.layering.show
+      show_layers if Kubes.config.layering.show
       result = render(@path) # main
       results = [result].flatten # ensure array
       data = results.map! do |main|
@@ -11,13 +11,22 @@ class Kubes::Compiler::Strategy
       Result.new(@save_file, data)
     end
 
+    def show_layers
+      logger.info "Compiling #{pretty_path(@path)}"
+      logger.info "    Resource layers:"
+      all_layers = pre_layers + [@path] + post_layers
+      all_layers.each do |layer|
+        logger.info "    #{pretty_path(layer)}"
+      end
+    end
+
     # Render via to Erb or one of the DSL syntax classes or Core/Blocks class
     def render(path)
       if path.include?('.rb')
         klass = dsl_class(path) # IE: Kubes::Compiler::Dsl::Syntax::Deployment or Kubes::Compiler::Dsl::Core::Blocks
         klass.new(@options.merge(path: path, data: @data)).run
       else
-        logger.info "Rendering #{pretty_path(path)}" if ENV['KUBES_LAYERING_SHOW_ALL']
+        logger.info "Rendering #{pretty_path(path)}" if ENV['KUBES_LAYERING_SHOW_RENDERING']
         Erb.new(@options.merge(data: @data)).render_result(path)
       end
     end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Improves to show layering flag. To activate, can use `export KUBES_LAYERING_SHOW=1`

Example

    $ export KUBES_LAYERING_SHOW=1
    $ kubes compile
    Compiling .kubes/resources/shared/namespace.yaml
        Resource layers:
        .kubes/resources/base/all.yaml
        .kubes/resources/shared/namespace.yaml
        Variables layers:
        .kubes/variables/base.rb
        .kubes/variables/dev.rb
    ...

Also to show **all** considered layers regardless of being found `export KUBES_LAYERING_SHOW_ALL=1`. Careful its noisy.

## How to Test

Sanity check

## Version Changes

Patch