### PR TITLE
kubes docker name

### DIFF
--- a/lib/kubes/cli/docker.rb
+++ b/lib/kubes/cli/docker.rb
@@ -9,7 +9,25 @@ class Kubes::CLI
       push if options[:push]
     end
 
-    desc "push IMAGE", "Push the docker image."
+    desc "name", "Print the full docker image with tag that was last generated."
+    long_desc Help.text("docker:name")
+    option :name, type: :boolean, default: false
+    def name
+      builder = Kubes::Docker.new(options, "build")
+      name = builder.read_image_name
+      if name
+        puts name
+      else
+        $stderr.puts(<<~EOL)
+          WARN: docker image has not yet been built. Please first run:
+
+              kubes docker build
+
+        EOL
+      end
+    end
+
+    desc "push", "Push the docker image."
     long_desc Help.text("docker:push")
     option :push, type: :boolean, default: false
     def push

--- a/lib/kubes/docker.rb
+++ b/lib/kubes/docker.rb
@@ -15,5 +15,8 @@ module Kubes
       klass_name = "Kubes::Docker::Strategy::#{@name.camelize}::#{strategy}"
       klass_name.constantize
     end
+
+    # For `kubes docker image` and read_image_name method
+    include Kubes::Docker::Strategy::ImageName
   end
 end

--- a/lib/kubes/docker/strategy/image_name.rb
+++ b/lib/kubes/docker/strategy/image_name.rb
@@ -19,6 +19,12 @@ module Kubes::Docker::Strategy
       IO.write(image_state_path, text)
     end
 
+    def read_image_name
+      return unless File.exist?(image_state_path)
+      data = IO.read(image_state_path).strip
+      JSON.load(data)['image']
+    end
+
     # output can get entirely wiped so dont use that folder
     def image_state_path
       Kubes.config.state.path


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add support for command:

    kubes docker name

It prints out the last built docker image name. Useful for connecting with other automation outside of kubes deploy. IE:

    kubes docker build
    kubes docker push
    NAME=$(kubes docker name)

Then can use `$NAME` in other scripts

## How to Test

    kubes docker build
    kubes docker name

## Version Changes

Patch